### PR TITLE
Handle Presence and Order of Required Page Blocks

### DIFF
--- a/patterns/page-general.php
+++ b/patterns/page-general.php
@@ -10,7 +10,7 @@
  */
 ?>
 
-<!-- wp:bc-sitka-spruce/narrow-content -->
+<!-- wp:bc-sitka-spruce/narrow-content {"lock":{"move":true,"remove":false}} -->
 <div class="wp-block-bc-sitka-spruce-narrow-content narrow-content"><!-- wp:mayflower-blocks/lead -->
 <div class="wp-block-mayflower-blocks-lead lead"></div>
 <!-- /wp:mayflower-blocks/lead -->

--- a/src/js/core/editor-data-helpers.js
+++ b/src/js/core/editor-data-helpers.js
@@ -28,8 +28,9 @@ export const pageTemplate = async () => {
 	return new Promise( ( resolve ) => {
 		const unsubscribe = subscribe( () => {
 			const { getEditedPostAttribute } = select('core/editor');
-			const templateSlug = getEditedPostAttribute('template');
-			if ( templateSlug ) {
+			let templateSlug = getEditedPostAttribute('template');
+			if ( templateSlug !== undefined ) {
+				templateSlug = templateSlug || 'default';
 				unsubscribe();
 				resolve( templateSlug );
 			}
@@ -62,4 +63,35 @@ export const getAllBlocks = async () => {
 			}
 		});
 	} );
+}
+
+/**
+ * Ensure that a specific pattern is at the top of the editor
+ *
+ * @param {array} allBlocks - An array of all blocks in the editor
+ * @param {string} blockName - The name of the block to check for
+ * @param {string} patternName - The name of the pattern to insert
+ */
+export function forcePatternToTop( allBlocks, blockName, patternName ) {
+
+	const templateIndex = allBlocks.findIndex( ( block ) => {
+		return block.name === blockName;
+	});
+
+	// No template found - create one!
+	if ( -1 === templateIndex ) {
+		console.log('Notice: ' + blockName + ' not found; applying template.');
+		const newBlock = createBlock( 'core/pattern', { 'slug': patternName } );
+		dispatch( 'core/block-editor' ).insertBlock( newBlock, 0 );
+		return;
+	} else if ( templateIndex > 0 ) {
+		console.log('Notice: ' + blockName + ' found at index', templateIndex, 'and will be migrated.');
+
+		// Move other blocks after the template - we can't move the template because it's locked
+		allBlocks.forEach( block => {
+			dispatch('core/block-editor').moveBlockToPosition( block.clientId, '', '', templateIndex + 1 );
+		});
+	} else {
+		console.log('Success: Block ' + blockName + ' found at index', templateIndex);
+	}
 }

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -1,39 +1,42 @@
-import { dispatch } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
-import { pageTemplate, isNewPost, isFrontPage, getAllBlocks } from './core/editor-data-helpers';
+import { isNewPost, isFrontPage, pageTemplate, getAllBlocks, forcePatternToTop } from './core/editor-data-helpers';
 
 
 // Thanks to https://github.com/WordPress/gutenberg/issues/28032#issuecomment-772720637 for the dom ready code!
 wp.domReady( async function () {
+
+	const blocks = await getAllBlocks();
 
 	if ( await isNewPost() ) {
 		console.log('Editing a New Post - No migration needed');
 		return;
 	}
 
-	if ( ! await isFrontPage() ) {
-		console.log('Not Editing the Front Page - No migration needed');
+	// Check if we are editing the front page
+	if ( await isFrontPage() ) {
+		forcePatternToTop( blocks, 'bc-sitka-spruce/template-homepage', 'bc-sitka-spruce/page-homepage' );
 		return;
 	}
 
-	// Find index of bc-sitka-spruce/template-homepage block
-	const blocks = await getAllBlocks();
-	const templateIndex = blocks.findIndex( ( block ) => {
-		return block.name === 'bc-sitka-spruce/template-homepage';
-	});
-
-
-
-	// No template found!
-	if ( -1 === templateIndex ) {
-		console.log('Notice: Homepage template not found; applying template.');
-		const newBlock = createBlock( 'bc-sitka-spruce/template-homepage' );
-		dispatch( 'core/block-editor' ).insertBlock(newBlock, 0);
-		// dispatch( 'core/block-editor' ).savePost(); // we may want to save automatically
-		console.log('Inserted Block!', newBlock);
-		return;
-	} else {
-		console.log('Homepage template found at index', templateIndex);
+	// Check if we are editing a page using the default template
+	if ( await pageTemplate() === 'default' ) {
+		forcePatternToTop( blocks, 'bc-sitka-spruce/narrow-content', 'bc-sitka-spruce/page' );
 	}
+
+	// Check if narrow content section exists somewhere on the 'no nav sidebar' page
+	if ( await pageTemplate() === 'template--no-sidebar.php' ) {
+		const templateIndex = blocks.findIndex( ( block ) => {
+			return block.name === 'bc-sitka-spruce/narrow-content';
+		});
+
+		// Move children out of the narrow content section and delete it
+		if ( -1 !== templateIndex ) {
+			const children = select( 'core/block-editor' ).getClientIdsOfDescendants( blocks[templateIndex].clientId );
+			dispatch( 'core/block-editor' ).moveBlocksToPosition( children, blocks[templateIndex].clientId, '', 0 );
+			dispatch( 'core/block-editor' ).removeBlock( blocks[templateIndex].clientId );
+		}
+	}
+
 });
 


### PR DESCRIPTION
1. Ensure homepage template blocks are always present at top of homepage (refresh may be required for scripts to run)
2. Ensure 'narrow content' template is always present at the top of normal pages (refresh may be required for scripts to run)
3. Remove 'narrow content' from pages if No Sidebar content is selected
4. Cleaned up code