### PR TITLE
Fix Default Heading Level of Callout

### DIFF
--- a/src/blocks/callout/render.php
+++ b/src/blocks/callout/render.php
@@ -13,7 +13,7 @@ $context['links'] = is_array( $links ) ? array_map( function ( $link ) {
 }, $links ) : null;
 
 $context['wrapper_classes'] = 'callout-wrapper col';
-$context['heading_tag'] = 'h5';
+$context['heading_tag'] = 'h3';
 
 
 


### PR DESCRIPTION
In most situations this falls within a section, so should be a H3. H5 was being used unless overridden.