### PR TITLE
Pre-Configure SEO Framework Plugin

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -305,7 +305,6 @@ add_filter(
 		$options['ld_json_searchbox'] = 0;
 		$options['sitemap_styles'] = 0;
 		$options['sitemap_logo'] = 0;
-		$options['ld_json_searchbox'] = 0;
 		return $options;
 	},
 	10,


### PR DESCRIPTION
Set defaults in SEO Framework to tweak archive indexes and default homepage title.

Note that these settings can still be modified - these just filter the defaults.

Resolves Metadata part of #130

## Setup instructions:
1. Install 'The SEO Framework' Plugin
2. Activate plugin
3. No config should be needed (theme now sets defaults)