### PR TITLE
Improve rendering of Course Info Section

### DIFF
--- a/src/blocks/course-information-section/course-information-section-content/index.js
+++ b/src/blocks/course-information-section/course-information-section-content/index.js
@@ -18,15 +18,15 @@ registerBlockType("bc-sitka-spruce/course-information-section-content", {
 
 		const TEMPLATE = [
 			[ "core/paragraph", {
-				placeholder: "Add an introduction to the courses in this degree or certificate."
+				placeholder: __( "Add an introduction to the courses in this degree or certificate (required).", "bc-sitka-spruce" ),
 			} ],
 			[ "core/paragraph", {
-				placeholder: "Add list descriptor (aka 'Example courses')"
+				placeholder: __( "Add list descriptor (aka 'Example courses')", "bc-sitka-spruce" ),
 			} ],
 			[ "core/list", {} ],
 			[ "mayflower-blocks/button-group", {}, [
 				[ "mayflower-blocks/button", {
-					placeholder: "Add Call-to-Action",
+					placeholder: __( "Add Call-to-Action", "bc-sitka-spruce" ),
 				}]
 			] ],
 			[ "bawb/program", {
@@ -42,7 +42,7 @@ registerBlockType("bc-sitka-spruce/course-information-section-content", {
 		return (
 			<div {...blockProps}>
 				<RichText
-					placeholder={__("Section Title", "bc-sitka-spruce")}
+					placeholder={ __("Section Title (Required)", "bc-sitka-spruce") }
 					tagName="h2"
 					onChange={(title) => props.setAttributes({ title })}
 					value={props.attributes.title}

--- a/src/blocks/course-information-section/course-information-section-content/render.php
+++ b/src/blocks/course-information-section/course-information-section-content/render.php
@@ -5,5 +5,9 @@ $context            = Timber::context();
 $context['title']   = esc_attr( $attributes['title'] ?? '' );
 $context['content'] = $content;
 
-// Render Twig Template
-Timber::render( '/stories/course-information-section/course-information-section-content.twig', $context );
+if ( ! empty( $attributes['title'] ) && ! empty( $content ) ) {
+	// Render Twig Template
+	Timber::render( '/stories/course-information-section/course-information-section-content.twig', $context );
+} else {
+	echo '';
+}

--- a/src/blocks/course-information-section/render.php
+++ b/src/blocks/course-information-section/render.php
@@ -5,4 +5,8 @@ $context = Timber::context();
 $context['content'] = $content;
 
 // Render Twig Template
-Timber::render( '/stories/course-information-section/course-information-section.twig', $context );
+if ( ! empty( $content ) ) {
+	Timber::render( '/stories/course-information-section/course-information-section.twig', $context );
+} else {
+	echo '';
+}


### PR DESCRIPTION
Prevent output to the degree possible when not filled in.

Partially resolves UI: Course Information Section Block help text needs update #274 and  Course Information Section Block displays without required fields #275

Note that this doesn't fully resolve these bug reports, but further improvement isn't possible without drastic changes to block structure, which probably isn't worth it. 