### PR TITLE
Fix Spacing on Support Homepage Without Hero Image

### DIFF
--- a/src/blocks/content-and-location/style.scss
+++ b/src/blocks/content-and-location/style.scss
@@ -38,7 +38,7 @@
 
 }
 
-.site-type-suppt .content-and-location.container-xl {
+.site-type-suppt .hero + .content-and-location.container-xl {
 
     @include media-breakpoint-up('lg') {
         margin-top: calc( var(--bs-gutter-x ) * -0.5 );


### PR DESCRIPTION
Prevent collapse of top margin when there is no hero image.