### PR TITLE
Prevent Homepage From Showing in Sidebar Nav

### DIFF
--- a/src/controllers/page-templates/page.php
+++ b/src/controllers/page-templates/page.php
@@ -33,6 +33,7 @@ if ( $context['post']->post_parent > 0 ) {
 			'sort_column' => 'menu_order',
 			'echo'        => false,
 			'depth'       => 2,
+			'exclude'     => get_option('page_on_front') ?? array(),
 		)
 	);
 }


### PR DESCRIPTION
Resolves issue where 'Home' would display twice in the sidebar navigation;
once at the top, and once in the list of pages.