### PR TITLE
Fix Link to Focus Areas in Degree Section Block

### DIFF
--- a/src/controllers/Program.php
+++ b/src/controllers/Program.php
@@ -52,11 +52,11 @@ class Program extends PostData {
 				return $pathway['title'];
 			}, $pathways ),
 			'pathways'      => $pathways,
-			'focus_areas'   => get_field( 'focus_areas', $post->ID ) ? array_map( function ( $focus_area ) {
+			'focus_areas'   => get_field( 'focus_areas', $post->ID ) ? array_map( function ( $focus_area ) use ( $pathways ) {
 				return array(
 					'id'    => $focus_area->ID,
 					'title' => $focus_area->post_title,
-					'url'   => get_permalink( $focus_area->ID ),
+					'url'   => 1 === count( $pathways ) ? esc_url( $pathways[0]['url'] . '#' . $focus_area->post_name . '-tab-open' ) :  false,
 				);
 			}, get_field( 'focus_areas', $post->ID )) : array(),
 		);

--- a/stories/degrees-certificates-section/degrees-certificates-section.twig
+++ b/stories/degrees-certificates-section/degrees-certificates-section.twig
@@ -42,10 +42,14 @@
 										<dd><ul class="list-unstyled">
 											{% for focus_area in program.focus_areas %}
 												<li>
-													<a href="{{ focus_area.url|esc_url }}" target="_blank">
-														{{ focus_area.title|esc_html }}<i class="fa-regular fa-square-arrow-up-right ms-1" aria-hidden="true"></i>
-														<span class="visually-hidden">{{ __( 'Opens in a new tab', 'bc-sitka-spruce' ) }}</span>
-													</a>
+													{% if focus_area.url %}
+														<a href="{{ focus_area.url|esc_url }}" target="_blank">
+															{{ focus_area.title|esc_html }}<i class="fa-regular fa-square-arrow-up-right ms-1" aria-hidden="true"></i>
+															<span class="visually-hidden">{{ __( 'Opens in a new tab', 'bc-sitka-spruce' ) }}</span>
+														</a>
+													{% else %}
+														{{ focus_area.title|esc_html }}
+													{% endif %}
 												</li>
 											{% endfor %}
 										</ul></dd>


### PR DESCRIPTION
If there is only one Pathway available, link to the Pathway page with Focus Area selected.

If there are multiple Pathways available, remove focus area link since it is not possible to determine the correct page.