### PR TITLE
Hide 'Hours' Heading in Footer if No Hours Available

### DIFF
--- a/stories/sock/standard-sock.twig
+++ b/stories/sock/standard-sock.twig
@@ -28,8 +28,10 @@
 						{{ location_image }}
 					</div>
 					<div class="col sock-hours">
-						<h2 class="h4">{{ __('Hours', 'bc-sitka-spruce') }}</h2>
-						{{ hours }}
+						{% if hours %}
+							<h2 class="h4">{{ __('Hours', 'bc-sitka-spruce') }}</h2>
+							{{ hours }}
+						{% endif %}
 						{% include '/stories/atoms/links/link-button.twig' with {
 							link: {
 								title: __('Contact Information', 'bc-sitka-spruce'),


### PR DESCRIPTION
The 'Hours' heading would stay present in the footer even if no hours were provided in Site Options