### PR TITLE
315-editor-ui-add-title-field-on-new-pages-is-aligned-too-far-left

### DIFF
--- a/src/scss/editor.scss
+++ b/src/scss/editor.scss
@@ -218,6 +218,7 @@ body.gutenberg-editor-page .editor-block-list__block {
   }
 }
 
+// Change Title Width - match 'wide style', but ensure there is at least 1rem of margin on each side.
 .editor-post-title {
-	max-width: var(--wp--style--global--wide-size) !important;
+	max-width: min( var(--wp--style--global--wide-size), calc( 100% - 2rem ) ) !important;
 }


### PR DESCRIPTION
Resolve Editor UI: "Add Title" field on new Pages is aligned too far left #315