### PR TITLE
🐛 FIX: Set Text Color on Links in `.text-white` Areas in Editor

### DIFF
--- a/src/scss/editor.scss
+++ b/src/scss/editor.scss
@@ -52,7 +52,10 @@ html :where(.wp-block) {
 		padding-left: 0;
 	}
 
-
+	.text-white a,
+  .text-white a:hover {
+		color: var(--white);
+	}
 }
 
 /* Style Quote Block */


### PR DESCRIPTION
Resolves Editor UI: Links on dark background in Accordion Section Collapsible is low contrast #321