### PR TITLE
Fix ACF Fields on Profile CPT in Firefox

### DIFF
--- a/acf-json/group_6691a05d5881e.json
+++ b/acf-json/group_6691a05d5881e.json
@@ -187,10 +187,11 @@
                 "id": ""
             },
             "default_value": "",
+            "allow_in_bindings": 1,
             "tabs": "visual",
             "toolbar": "basic",
             "media_upload": 0,
-            "delay": 0
+            "delay": 1
         },
         {
             "key": "field_6691a6bce8497",
@@ -207,10 +208,11 @@
                 "id": ""
             },
             "default_value": "",
+            "allow_in_bindings": 1,
             "tabs": "visual",
             "toolbar": "basic",
             "media_upload": 0,
-            "delay": 0
+            "delay": 1
         },
         {
             "key": "field_6691a6cde8498",
@@ -400,5 +402,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1735851351
+    "modified": 1747080688
 }


### PR DESCRIPTION
Apply ACF's recommended fixes to resolve issues with WYSIWYG fields in Firefox.
They now require a click to initialize before being usable, but will work across browsers.