### PR TITLE
Add Anchor Support to Listing Section and List Item Blocks

### DIFF
--- a/src/blocks/listing-section/block.json
+++ b/src/blocks/listing-section/block.json
@@ -9,6 +9,7 @@
     "version": "1.0.0",
     "textdomain": "bc-sitka-spruce",
     "supports": {
+        "anchor": true,
         "html": false
     },
 	"allowedBlocks": [
@@ -20,6 +21,10 @@
         },
         "description": {
             "type": "string"
+        },
+        "anchor": {
+            "type": "string",
+            "default": null
         }
     },
     "editorScript": "file:./index.js",

--- a/src/blocks/listing-section/index.js
+++ b/src/blocks/listing-section/index.js
@@ -11,11 +11,12 @@ import { Card, CardBody, CardHeader } from "@wordpress/components";
 registerBlockType("bc-sitka-spruce/listing-section", {
 	edit: function (props) {
 		const {
-			attributes: { title, description },
+			attributes: { title, description, anchor },
 			setAttributes,
 			isSelected,
 		} = props;
 		const blockProps = useBlockProps({
+			id: anchor,
 			className: "section section-xlight listing-section-wrapper alignfull",
 		});
 

--- a/src/blocks/listing-section/listing-section-list-item/block.json
+++ b/src/blocks/listing-section/listing-section-list-item/block.json
@@ -9,7 +9,8 @@
     "version": "1.0.0",
     "textdomain": "bc-sitka-spruce",
     "supports": {
-        "html": false
+        "html": false,
+        "anchor": true
     },
 	"allowedBlocks": [
 		"core/paragraph",
@@ -36,7 +37,11 @@
 		"imageAlt": {
 			"type": "string",
 			"default": ""
-		}
+		},
+		"anchor": {
+            "type": "string",
+            "default": null
+        }
     },
     "editorScript": "file:./index.js",
     "render": "file:./render.php"

--- a/src/blocks/listing-section/listing-section-list-item/index.js
+++ b/src/blocks/listing-section/listing-section-list-item/index.js
@@ -23,12 +23,13 @@ import { Card, CardBody, CardHeader } from "@wordpress/components";
 registerBlockType("bc-sitka-spruce/listing-section-list-item", {
 	edit: function (props) {
 		const {
-			attributes: { title, placeholder, imageId, imageUrl, imageAlt },
+			attributes: { title, placeholder, imageId, imageUrl, imageAlt, anchor },
 			setAttributes,
 			isSelected,
 		} = props;
 
 		const blockProps = useBlockProps({
+			id: anchor,
 			className: "list-item row",
 		});
 

--- a/src/blocks/listing-section/listing-section-list-item/render.php
+++ b/src/blocks/listing-section/listing-section-list-item/render.php
@@ -7,6 +7,7 @@ $context = Timber::context();
 $context['title']   = esc_html( $attributes['title'] ?? '' );
 $context['content'] = $content ?? '';
 $context['image']   = $attributes['imageId'] ? wp_get_attachment_image( $attributes['imageId'], 'listing-section', false, array( 'class' => 'img-fluid rounded' ) ) : null;
+$context['anchor']  = $attributes['anchor'] ?? null;
 
 // Render Twig Template
 if ( $context['title'] ) {

--- a/src/blocks/listing-section/render.php
+++ b/src/blocks/listing-section/render.php
@@ -7,6 +7,7 @@ $context = Timber::context();
 $context['title']       = esc_html( $attributes['title'] ?? '' );
 $context['description'] = wp_kses_post( $attributes['description'] ?? '' );
 $context['list_items']  = $content;
+$context['anchor']      = $attributes['anchor'] ?? null;
 
 // Render Twig Template
 Timber::render( '/stories/listing-section/listing-section.twig', $context );

--- a/stories/listing-section/list-item.twig
+++ b/stories/listing-section/list-item.twig
@@ -1,6 +1,6 @@
 <div class="list-item row">
 	<div class="col-md-8">
-		<h3>{{ title|esc_html }}</h3>
+		<h3 {% if anchor %}id="{{ anchor|esc_attr }}"{% endif %}>{{ title|esc_html }}</h3>
 		{{ content|wp_kses_post }}
 		<p>{{ description|esc_html }}</p>
 

--- a/stories/listing-section/listing-section.twig
+++ b/stories/listing-section/listing-section.twig
@@ -8,7 +8,8 @@
 <section class="section section-xlight listing-section-wrapper">
 	{% include '/stories/section-heading/section-heading.twig' with {
 		'heading': title,
-		'subheading': description
+		'subheading': description,
+		'anchor': anchor
 	} %}
 	<div class="listing-section container-xl">
 		{{ list_items }}

--- a/stories/section-heading/section-heading.twig
+++ b/stories/section-heading/section-heading.twig
@@ -35,7 +35,7 @@
           <div class="eyebrow">{{ eyebrow }}</div>
         {% endif %}
       <div class="col-sm-12 col-md-9 small-order-1 medium-order-1">
-         <h2 class="section-heading__heading oho-animate oho-animate-single">
+         <h2 {% if anchor %} id="{{ anchor }}" {% endif %} class="section-heading__heading oho-animate oho-animate-single">
           {{ heading }}
         </h2>
       </div>

--- a/stories/section-heading/section-heading.twig
+++ b/stories/section-heading/section-heading.twig
@@ -35,7 +35,7 @@
           <div class="eyebrow">{{ eyebrow }}</div>
         {% endif %}
       <div class="col-sm-12 col-md-9 small-order-1 medium-order-1">
-         <h2 {% if anchor %} id="{{ anchor }}" {% endif %} class="section-heading__heading oho-animate oho-animate-single">
+         <h2 {% if anchor %} id="{{ anchor|esc_attr }}" {% endif %} class="section-heading__heading oho-animate oho-animate-single">
           {{ heading }}
         </h2>
       </div>


### PR DESCRIPTION
Related to #340

Adds an Anchor section under Advanced in the sidebar for Listing Section and List Item blocks within it.

By entering an 'anchor' here, it'll be set as the ID of the element, and allow direct linking to that position on the page. 