### PR TITLE
👌 IMPROVE: Add Toggle to Hide Page from Sidebar Nav

### DIFF
--- a/acf-json/group_66fd6d14bbca3.json
+++ b/acf-json/group_66fd6d14bbca3.json
@@ -47,6 +47,27 @@
             "rows": "",
             "placeholder": "",
             "new_lines": ""
+        },
+        {
+            "key": "field_687ebbeb3a1d1",
+            "label": "Hide from Sidebar Navigation",
+            "name": "hide_from_side_nav",
+            "aria-label": "",
+            "type": "true_false",
+            "instructions": "Enabling this setting will prevent this page from being listed in the auto-generated navigation sidebar.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "allow_in_bindings": 0,
+            "ui_on_text": "Hidden",
+            "ui_off_text": "Shown",
+            "ui": 1
         }
     ],
     "location": [
@@ -72,5 +93,5 @@
     "active": true,
     "description": "Custom Fields displayed on Pages that aren't the homepage",
     "show_in_rest": 0,
-    "modified": 1735851193
+    "modified": 1753136405
 }

--- a/src/controllers/page-templates/page.php
+++ b/src/controllers/page-templates/page.php
@@ -12,6 +12,26 @@ $context['header_image'] = get_field( 'header_image' ) ?
 	wp_get_attachment_image( get_field( 'header_image' ), 'featured-page', false, array( 'class' => 'img-fluid rounded' ) ) : null;
 $context['intro_text']   = esc_html( get_field( 'intro_text' ) ?? '' );
 
+// Get pages to hide from side nav
+$pages_to_hide = get_posts( array(
+	'posts_per_page'    => -1,
+	'post_type'         => 'page',
+	'fields'            => 'ids',
+	'meta_query' => array(
+		array(
+			'key'   => 'hide_from_side_nav',
+			'value' => '1',
+		)
+	)
+) );
+
+// Add front page to hide list if it exists
+if ( get_option( 'page_on_front' ) ) {
+	$pages_to_hide[] = get_option( 'page_on_front' );
+}
+
+// Implode the pages array to a comma separated string
+$pages_to_hide = implode( ',', $pages_to_hide );
 
 if ( $context['post']->post_parent > 0 ) {
 	$context['parent_page']['title'] = get_the_title( $context['post']->post_parent );
@@ -21,6 +41,7 @@ if ( $context['post']->post_parent > 0 ) {
 			'sort_column' => 'menu_order',
 			'echo'        => false,
 			'child_of'    => $context['post']->post_parent,
+			'exclude'     => $pages_to_hide,
 			'depth'       => 2,
 		)
 	);
@@ -33,7 +54,7 @@ if ( $context['post']->post_parent > 0 ) {
 			'sort_column' => 'menu_order',
 			'echo'        => false,
 			'depth'       => 2,
-			'exclude'     => get_option('page_on_front') ?? array(),
+			'exclude'     => $pages_to_hide,
 		)
 	);
 }


### PR DESCRIPTION
Adds a new toggle to the editing sidebar on pages that allows the current page
to be hidden globally from sidebar navigation.

Note that the page will still display in any manually created navigation menus.

Note: Informal request from Maura for use on OLS site and others. This is designed for pages like confirmation pages, which should not be organically findable.