### PR TITLE
📦 NEW: Add Front-End Warnings for Alt Text

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -104,6 +104,10 @@ $enqueuer->addStyle( handle: 'bc-sitka-spruce-fonts', src: '//use.typekit.net/vl
 
 $enqueuer->addScript( handle: 'bc-sitka-spruce-main-js', src: '/assets/dist/js/main.asset.php', use_asset_file: true );
 
+if ( current_user_can( 'edit_posts' ) ) {
+	$enqueuer->addScript( handle: 'bc-sitka-spruce-a11y-warnings', src: '/assets/dist/js/a11y-warnings.asset.php', use_asset_file: true );
+}
+
 // Enqueue Script in Block Editor to Handle Automated Block Insertion Etc
 add_action( 'enqueue_block_editor_assets', function () {
 	$asset = include get_parent_theme_file_path( '/assets/dist/js/editor.asset.php' );

--- a/src/js/a11y-warnings.js
+++ b/src/js/a11y-warnings.js
@@ -1,0 +1,45 @@
+import { Tooltip } from 'bootstrap';
+
+document.addEventListener('DOMContentLoaded', () => {
+    // Images without alt attribute
+    document.querySelectorAll('#main-content img:not([alt])').forEach(img => {
+        img.setAttribute('data-bs-toggle', 'tooltip');
+        img.setAttribute('data-bs-placement', 'top');
+        img.setAttribute('data-bs-html', 'true');
+        img.setAttribute('data-bs-title', '⚠️ <strong>Accessibility Warning</strong><br>Missing ALT text. This image needs alternative text.');
+        img.setAttribute('data-bs-trigger', 'hover focus');
+        img.classList.add('a11y-warning');
+    });
+
+    // Images with empty alt attribute
+    document.querySelectorAll('#main-content img[alt=""]').forEach(img => {
+        img.setAttribute('data-bs-toggle', 'tooltip');
+        img.setAttribute('data-bs-placement', 'top');
+        img.setAttribute('data-bs-html', 'true');
+        img.setAttribute('data-bs-title', 'ℹ️ <strong>Accessibility Notice</strong><br>Empty ALT text. Only use if image is purely decorative.');
+        img.setAttribute('data-bs-trigger', 'hover focus');
+        img.classList.add('a11y-notice');
+    });
+
+    // Images with empty alt inside links
+    document.querySelectorAll('#main-content a > img[alt=""]').forEach(img => {
+        img.setAttribute('data-bs-toggle', 'tooltip');
+        img.setAttribute('data-bs-placement', 'top');
+        img.setAttribute('data-bs-html', 'true');
+        img.setAttribute('data-bs-title', '⚠️ <strong>Accessibility Warning</strong><br>Linked image needs descriptive ALT text.');
+        img.setAttribute('data-bs-trigger', 'hover focus');
+        img.classList.add('a11y-warning');
+    });
+
+    // Initialize tooltips with error handling
+    document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(element => {
+        try {
+            new Tooltip(element, {
+                html: true,
+                boundary: document.body
+            });
+        } catch (e) {
+            console.warn('Error initializing tooltip:', e);
+        }
+    });
+});

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -86,12 +86,12 @@ $header-desktop-breakpoint: lg;
 // A11y Warnings
 .a11y-notice,
 .a11y-warning {
-	outline: 5px dashed;
+	border: 5px dashed;
 }
 
 .a11y-notice {
-	outline-color: orange;
+	border-color: orange;
 }
 .a11y-warning {
-	outline-color: red;
+	border-color: red;
 }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -82,3 +82,16 @@ $header-desktop-breakpoint: lg;
 	}
 
 }
+
+// A11y Warnings
+.a11y-notice,
+.a11y-warning {
+	outline: 5px dashed;
+}
+
+.a11y-notice {
+	outline-color: orange;
+}
+.a11y-warning {
+	outline-color: red;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,7 @@ const customPaths = Object.assign( {}, defaultConfig, {
 		...scssEntryPoint( 'lmc-search', true ),
 		'js/main': path.resolve( process.cwd(), 'src/js', 'main.js' ),
 		'js/editor': path.resolve( process.cwd(), 'src/js', 'editor.js' ),
+		'js/a11y-warnings': path.resolve( process.cwd(), 'src/js', 'a11y-warnings.js' ),
 		'blocks/contact-selector/index': path.resolve( process.cwd(), 'src/blocks/contact-selector', 'style.scss' )
 	},
 } );


### PR DESCRIPTION
Bring over functionality inspired by Douglas Fir. Displays a colorful outline around images
with missing alt text, and provides a tooltip for more info.

Please review and let me know how this works for you, and how you think it could be improved. 