### PR TITLE
📦 NEW:  Add Support for `wp_body_open()`

### DIFF
--- a/views/system/html.twig
+++ b/views/system/html.twig
@@ -32,6 +32,7 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N665V3"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
+		{{ function('wp_body_open') }}
     {% block wrapper %}{% endblock %}
   </body>
 </html>


### PR DESCRIPTION
Allow future improvements to emergency alerting and other systems by adding support for `wp_body_open()` hook