### PR TITLE
Fix Auto-Population of Missing Required Blocks

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -114,8 +114,23 @@ add_action( 'enqueue_block_editor_assets', function () {
 	wp_enqueue_script(
 		'sitka-editor-js',
 		get_template_directory_uri() . '/assets/dist/js/editor.js',
-		array_unique( array_merge( array( 'wp-blocks', 'wp-dom-ready', 'wp-edit-post' ) , $asset['dependencies'] ) ),
+		array_unique(
+			array_merge(
+				array( 'wp-blocks', 'wp-dom-ready', 'wp-edit-post' ),
+				$asset['dependencies']
+			)
+		),
 		$asset['version']
+	);
+
+	$front_page_id = (int) get_option( 'page_on_front' );
+
+	$inline = "window.SitkaEditor = Object.assign( window.SitkaEditor || {}, { frontPageId: $front_page_id } );";
+
+	wp_add_inline_script(
+		'sitka-editor-js', // must match the handle above
+		$inline,
+		'before'           // ensure this runs before editor.js [web:64]
 	);
 } );
 

--- a/src/js/core/editor-data-helpers.js
+++ b/src/js/core/editor-data-helpers.js
@@ -3,25 +3,23 @@ import { createBlock } from '@wordpress/blocks';
 
 export const isFrontPage = async () => {
 	return new Promise( ( resolve ) => {
+		const frontPageId = window.SitkaEditor?.frontPageId;
+
+		if ( ! frontPageId ) {
+			resolve( false );
+			return;
+		}
+
 		const unsubscribe = subscribe( () => {
-
-			// Front Page ID
-			const siteStore = select('core');
-			const frontPageId = siteStore.getEntityRecord('root', 'site')?.page_on_front;
-
-			// Get current page ID
 			const currentPostId = select( 'core/editor' ).getCurrentPostId();
-			if ( frontPageId && currentPostId ) {
+
+			if ( currentPostId !== null ) {
 				unsubscribe();
-				if ( frontPageId === currentPostId ) {
-					resolve( true );
-				} else {
-					resolve( false );
-				}
+				resolve( frontPageId === currentPostId );
 			}
-		});
+		} );
 	} );
-}
+};
 
 
 export const pageTemplate = async () => {


### PR DESCRIPTION
When creating or editing pages via a non-administrative account auto-block insertion was failing due to missing data access permissions.

A work-around was added to allow more permissive access to the front page ID (non-sensitive).