### PR TITLE
Profile Detail Page FE A11y: Placeholder Image with Decorative Alt Text Throws Warnings #475 & Profile Listing FE A11y: Placeholder Images Contain Decorative Alt Text #476

### DIFF
--- a/stories/profile-detail-overview-content/ProfileDetailContent.stories.js
+++ b/stories/profile-detail-overview-content/ProfileDetailContent.stories.js
@@ -38,7 +38,7 @@ const Template = ( {
 
 export const Default = Template.bind({});
 Default.args = {
-    profile_image: '<img class="rounded img-fluid" src="https://picsum.photos/id/237/460/460" alt="Placeholder Image"></img>',
+    profile_image: '<img class="rounded img-fluid a11y-decorative" src="https://picsum.photos/id/237/460/460" alt="Placeholder Image"></img>',
     first_name: "John",
     last_name: "Doe",
     position: "Manager",

--- a/stories/profile-detail-overview-content/details-content.twig
+++ b/stories/profile-detail-overview-content/details-content.twig
@@ -10,11 +10,11 @@
 					{{ profile_image | replace({'alt=""': 'alt="'~ first_name ~ ' ' ~ last_name ~ '"'}) | raw }}				
 				{% else %}
 					{# Fallback to Default Image using theme.link #}
-					<img class="img-fluid rounded" 
+					<img class="img-fluid rounded a11y-decorative" 
 						width="460" height="460"
 						src="{{ theme.link }}/assets/img/basic-img.svg" 
 						alt="{{ __('', 'bc-sitka-spruce')}}">
-        			{% endif %}
+        		{% endif %}
 				</div>
 			</div>
 			<div class="profile-overview-column1 col-md-6">

--- a/stories/profiles-section/profiles-section.twig
+++ b/stories/profiles-section/profiles-section.twig
@@ -27,7 +27,7 @@
 										{# Targets WP's empty alt attribute and replaces it with just the name #}
 										{{ profile.profile_image | replace({'alt=""': 'alt="' ~ profile.first_name ~ ' ' ~ profile.last_name ~ '\'\s Profile"'}) | raw }}
 									{% else %}
-										<img class="rounded-top img-fluid" src="{{theme.link}}/assets/img/basic-img.svg" alt="{{ __(''~ profile.first_name ~' '~ profile.last_name ~'\'\s Profile', 'bc-sitka-spruce') }}">
+										<img class="rounded-top img-fluid a11y-decorative" src="{{theme.link}}/assets/img/basic-img.svg" alt="{{ __(''~ profile.first_name ~' '~ profile.last_name ~'\'\s Profile', 'bc-sitka-spruce') }}">
 									{% endif %}
 								</a>
 								<div class="p-2">

--- a/views/content/subcomponents/profile-list-element.twig
+++ b/views/content/subcomponents/profile-list-element.twig
@@ -21,11 +21,18 @@
 	<div class="col-auto">
 		<a href="{{ profile_url|esc_url }}" class="d-block">
 			{% if profile_image_id %}
-				<img src="{{ get_image(profile_image_id).src('thumbnail') }}" alt="{{ __('%s %s', 'bc-sitka-spruce')|format(first_name|esc_attr, last_name|esc_attr ) }}" class="img-fluid rounded">
+				{% set profile_img_obj = get_image(profile_image_id) %}
+
+				{# if there alt text in media library? if not, use this as default!#}
+				{% set image_alt = profile_img_obj.alt ? profile_img_obj.alt : first_name ~ ' ' ~ last_name ~ '\'s Profile' %}
+				<img src="{{ profile_img_obj.src('thumbnail') }}"
+					alt="{{ image_alt|esc_attr }}" 
+					class="img-fluid rounded"
+					width="150" height="150">
 			{% else %}
 			{# Fallback to Default Image #}
 				<img src="{{ theme.link }}/assets/img/basic-img.svg" 
-					alt="{{ __('', 'bc-sitka-spruce')}}" 
+					alt="{{ first_name|esc_attr }} {{ last_name|esc_attr }}'s Profile"
 					class="img-fluid rounded"
 					width="150" height="150">
 			{% endif %}


### PR DESCRIPTION
changed how alt text is handled & displayed