### PR TITLE
Improve Tab Inserter Display in iFramed Editor

### DIFF
--- a/src/blocks/tabcordion/editor.scss
+++ b/src/blocks/tabcordion/editor.scss
@@ -8,6 +8,23 @@
 */
 
 /**
+* Add Tab Button
+*/
+.wp-block-bc-sitka-spruce-tabcordion-list button.add-tab {
+	padding: 10px 5px;
+	color: #222;
+	border-radius: var(--bs-border-radius);
+	align-items: center;
+	background-color: var(--white);
+	border: 2px solid var(--gray--light);
+
+	&:hover, &:focus {
+		border: 2px solid var(--gray--medium);
+	}
+
+}
+
+/**
 * Pill Format
 */
 .wp-block-bc-sitka-spruce-tabcordion.tabcordion-pills {
@@ -32,24 +49,7 @@
 			float: left;
 			border: 1px solid transparent;
 
-			button.add-tab {
-				padding: 10px 10px;
-				color: #555555;
-				border-radius: 4px 4px 0 0;
-				align-items: center;
-				&:hover {
-					border: 1px solid #ddd;
-					margin: -1px;
-				}
 
-				span {
-					margin-left: 10px;
-				}
-
-				span.dashicon {
-					margin-left: 0px;
-				}
-			}
 
 			a {
 				background-color: var( --bc-brutus-blue );
@@ -130,26 +130,6 @@
 		li[role="presentation"] {
 			float: left;
 			border: 1px solid transparent;
-
-			button.add-tab {
-				padding: 10px 15px;
-				color: #555555;
-				border-radius: 4px 4px 0 0;
-				align-items: center;
-				&:hover {
-					border: 1px solid #ddd;
-					border-bottom-color: transparent;
-					margin: -1px;
-				}
-
-				span {
-					margin-left: 10px;
-				}
-
-				span.dashicon {
-					margin-left: 0px;
-				}
-			}
 
 			a {
 				text-decoration: none;

--- a/src/blocks/tabcordion/tabcordion-list/edit.js
+++ b/src/blocks/tabcordion/tabcordion-list/edit.js
@@ -10,10 +10,7 @@ import { createBlock } from '@wordpress/blocks';
 
 import { RichText } from '@wordpress/block-editor';
 
-import {
-	Button,
-	Dashicon
-} from '@wordpress/components';
+import { Button } from '@wordpress/components';
 
 import {
 	useBlockProps,
@@ -87,8 +84,6 @@ export default function Edit( props ) {
 		}
 	};
 
-
-
 	return (
 		<ul {...blockProps } >
 			<InnerBlocks
@@ -99,8 +94,8 @@ export default function Edit( props ) {
 			/>
 			<li role="presentation">
 				<Button onClick={ addTab } className="add-tab">
-					<Dashicon icon="insert" />
-					{ currentBlockData.innerBlocks.length === 0 ? <span>Add Tab</span> : '' }
+					<i className="fa-solid fa-plus add-tab-icon" aria-hidden="true" />
+					{ currentBlockData.innerBlocks.length === 0 ? <span>Add Tab</span> : <span className="screen-reader-text">Add Tab</span> }
 				</Button>
 			</li>
 		</ul>


### PR DESCRIPTION
Switch inserter icon to use FontAwesome for more reliable display. Only applies to Tabcordion block at this time. 