### PR TITLE
Hotfix v1.9.3: Fixed issues 519 & 520, cleaned up ressidual code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-sitka-spruce-department-theme",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Bellevue College Theme for Level 3 Department Sites",
   "main": "theme.json",
   "scripts": {

--- a/src/blocks/tabcordion/tabcordion-list-tab/edit.js
+++ b/src/blocks/tabcordion/tabcordion-list-tab/edit.js
@@ -156,13 +156,9 @@ export default function Edit( props ) {
 	const handleUpdateTabTitle = ( newTabTitle ) => {
 		// Update attribute on this block
 		setAttributes( { tabTitle: newTabTitle } );
-		const targetTabPanel = tabContentBlock.innerBlocks.find( (block) => block.attributes.tabId === tabId );
-		console.log();
-		// Update attribute on the corresponding tab panel
-		// tabContentBlock.innerBlocks.forEach( panel => {
+		const targetTabPanel = tabContentBlock.innerBlocks.find( ( block ) => block.attributes.tabId === tabId );
 
 		dispatch( 'core/block-editor' ).updateBlockAttributes( targetTabPanel.clientId, { tabTitle: newTabTitle } );
-		// } );
 
 	}
 

--- a/src/blocks/tabcordion/tabcordion-list/edit.js
+++ b/src/blocks/tabcordion/tabcordion-list/edit.js
@@ -4,11 +4,11 @@
 
 import { __ } from '@wordpress/i18n';
 
-import { select, dispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+
+import { select, dispatch, useSelect } from '@wordpress/data';
 
 import { createBlock } from '@wordpress/blocks';
-
-import { RichText } from '@wordpress/block-editor';
 
 import { Button } from '@wordpress/components';
 
@@ -17,17 +17,111 @@ import {
 	InnerBlocks
 } from '@wordpress/block-editor';
 
+/**
+ * Keeps mobile accordion order in sync with tab order.
+ *
+ * Tabs and their content are stored as two separate lists. Dragging a tab
+ * only changes the tab list, but on mobile the accordion shows panels in
+ * the order they appear in the content list — so we reorder panels to match.
+ *
+ * @param {string} tabListClientId Client ID of the tabcordion-list block.
+ */
+const syncPanelOrderToTabList = ( tabListClientId ) => {
+	const blockEditor = select( 'core/block-editor' );
+	const parentTabsBlock = blockEditor.getBlock( blockEditor.getBlockRootClientId( tabListClientId ) );
+	const tabListBlock = blockEditor.getBlock( tabListClientId );
+
+	// The block might still be loading or getting deleted — wait until it's ready.
+	if ( ! parentTabsBlock || ! tabListBlock ) {
+		return;
+	}
+
+	// Panel content is stored in a separate block next to the tab list.
+	const tabContentBlock = parentTabsBlock.innerBlocks.find( ( child ) => {
+		return child.name === 'bc-sitka-spruce/tabcordion-content';
+	} );
+
+	// Can't reorder panels if the content area doesn't exist yet.
+	if ( ! tabContentBlock ) {
+		return;
+	}
+
+	const tabOrder = tabListBlock.innerBlocks.map( ( tab ) => tab.attributes.tabId );
+	const panelOrder = tabContentBlock.innerBlocks.map( ( panel ) => panel.attributes.tabId );
+	// Check if the tab order and panel order have the same length and if the tab order is the same as the panel order
+	const hasOrderMismatch = tabOrder.length !== panelOrder.length
+		|| tabOrder.some( ( tabId, index ) => tabId !== panelOrder[ index ] );
+
+	// Panels are already in the right order — no changes needed.
+	if ( ! hasOrderMismatch ) {
+		return;
+	}
+
+	const { moveBlockToPosition } = dispatch( 'core/block-editor' );
+
+	for ( let targetIndex = 0; targetIndex < tabOrder.length; targetIndex++ ) {
+		// Check the current order again after each move, since positions change.
+		const currentTabContentBlock = blockEditor.getBlock( tabContentBlock.clientId );
+
+		// Stop if the content area was removed (for example, the user hit undo).
+		if ( ! currentTabContentBlock ) {
+			return;
+		}
+
+		const panelBlock = currentTabContentBlock.innerBlocks.find( ( panel ) => {
+			return panel.attributes.tabId === tabOrder[ targetIndex ];
+		} );
+
+		// This tab has no matching panel — move on to the next one.
+		if ( ! panelBlock ) {
+			continue;
+		}
+
+		const currentIndex = currentTabContentBlock.innerBlocks.findIndex( ( panel ) => {
+			return panel.clientId === panelBlock.clientId;
+		} );
+
+		if ( currentIndex !== targetIndex ) {
+			moveBlockToPosition(
+				panelBlock.clientId,
+				tabContentBlock.clientId,
+				tabContentBlock.clientId,
+				targetIndex
+			);
+		}
+	}
+};
+
 export default function Edit( props ) {
 	const blockProps = useBlockProps({
 		className: 'nav nav-tabs',
 		role: 'tablist',
 	});
-	const { attributes: {
+	const { clientId } = props;
 
-	}, isSelected, clientId } = props;
-
-	// Get the current tabcordion-list block with the clientId
 	const currentBlockData = select( 'core/block-editor' ).getBlock( clientId );
+
+	// Watch the tab list order so we know when the user drags tabs around.
+	const tabOrderKey = useSelect( ( selectFn ) => {
+		const tabListBlock = selectFn( 'core/block-editor' ).getBlock( clientId );
+
+		// The block isn't ready yet — this is normal when the page first loads.
+		if ( ! tabListBlock ) {
+			return '';
+		}
+
+		return tabListBlock.innerBlocks.map( ( tab ) => tab.clientId ).join( ',' );
+	}, [ clientId ] );
+
+	// Fix panel order when the page loads and whenever tabs are reordered.
+	useEffect( () => {
+		// No tabs yet — nothing to sync.
+		if ( ! tabOrderKey ) {
+			return;
+		}
+
+		syncPanelOrderToTabList( clientId );
+	}, [ clientId, tabOrderKey ] );
 
 	/**
 		 * Adds a Tab Block (child) as an innerblock to the Tab List Block (parent).

--- a/src/controllers/page-templates/archive-action-item.php
+++ b/src/controllers/page-templates/archive-action-item.php
@@ -11,29 +11,14 @@ $context['title'] = 'Board of Trustees Action Items'; // Fallback title
 $args = array(
     'post_type'      => 'action-item',
     'posts_per_page' => -1, // Get all of them'
-    //allows posts w/o meta_key in results
-    'meta_query'     => array(
-        'relation' => 'OR',
-        array(
-            'key'     => 'meeting_date',
-            'compare' => 'EXISTS',
-        ),
-        array(
-            'key'     => 'meeting_date',
-            'compare' => 'NOT EXISTS',
-        ),
-    ),
-    'orderby' => array(
-        'meta_value' => 'DESC',
-        'date'       => 'DESC', // Secondary sort by publish date
-    ),
 );
 $agendas = Timber::get_posts( $args );
 
-//Group them by Year (this is how they were grouped in douglas theme)
+//Group them by Year 
 $posts_by_year = array();
 foreach ( $agendas as $agenda ) {
     $year = null; // always reset (to prevent hiccup date associated with last item)
+    $sort_time = 0;
     $meeting_date = $agenda->meta('meeting_date');
 
     if ( ! empty( $meeting_date ) ) {
@@ -46,22 +31,38 @@ foreach ( $agendas as $agenda ) {
 
         if ( $date_time ) {
             $year = $date_time->format( 'Y' );
-            $agenda->localized_meeting_date = wp_date( 'F j, Y', $date_time->getTimestamp(), wp_timezone() );
+            $sort_time = $date_time->getTimestamp();
+            $agenda->localized_meeting_date = wp_date( 'F j, Y', $sort_time, wp_timezone() );
         }
     } else {
         // Fallback to WP publish date for the year group
-        $post_timestamp = strtotime( $agenda->post_date );
-        $year = gmdate( 'Y', $post_timestamp );
-        $agenda->localized_meeting_date = wp_date( 'F j, Y', $post_timestamp );
+        $date_time = date_create_immutable( $agenda->post_date, wp_timezone() );
+
+        if ( $date_time ) {
+            $year = $date_time->format( 'Y' );
+            $sort_time = $date_time->getTimestamp();
+            $agenda->localized_meeting_date = wp_date( 'F j, Y', $sort_time, wp_timezone() );
+        }
     }
 
     if ( $year ) {
+        // Attach raw sort timestamp for sorting inside the year group
+        $agenda->sort_timestamp = $sort_time;
         $posts_by_year[ $year ][] = $agenda;
     }
 }
 
 //Sort so the years are in descending order (newest/latest to oldest/earliest)
 krsort( $posts_by_year );
+
+//Sort posts w/in each year descending by date
+foreach ( $posts_by_year as $year => &$posts ) {
+    usort( $posts, function( $a, $b ) {
+        return $b->sort_timestamp <=> $a->sort_timestamp;
+    } );
+}
+unset( $posts ); // break reference
+
 //Pass  to Twig
 $context['posts_by_year'] = $posts_by_year;
 

--- a/src/controllers/page-templates/archive-resolution.php
+++ b/src/controllers/page-templates/archive-resolution.php
@@ -7,33 +7,18 @@
 $context = Timber::context();
 $context['title'] = 'Board of Trustees Resolutions'; // Fallback title
 
-//All Resolution(s)- ordered by the meeting date
+//All Resolution(s)- ordered by the meeting date (then publish date)
 $args = array(
     'post_type'      => 'resolution',
     'posts_per_page' => -1, // Get all of them
-    // allows posts w/o meta_key in results
-    'meta_query'     => array(
-        'relation' => 'OR',
-        array(
-            'key'     => 'meeting_date',
-            'compare' => 'EXISTS',
-        ),
-        array(
-            'key'     => 'meeting_date',
-            'compare' => 'NOT EXISTS',
-        ),
-    ),
-    'orderby' => array(
-        'meta_value' => 'DESC',
-        'date'       => 'DESC', // Secondary sort by publish date
-    ),
 );
 $agendas = Timber::get_posts( $args );
 
-//Group them by Year (this is how they were grouped in douglas theme)
+//Group them by Year 
 $posts_by_year = array();
 foreach ( $agendas as $agenda ) {
     $year = null; // always reset
+    $sort_time    = 0;
     // try to get ACF details date first
     $meeting_date = $agenda->meta('meeting_date');
 
@@ -47,23 +32,37 @@ foreach ( $agendas as $agenda ) {
 
         if ( $date_time ) {
             $year = $date_time->format( 'Y' );
-            $agenda->localized_meeting_date = wp_date( 'F j, Y', $date_time->getTimestamp(), wp_timezone() );
+            $sort_time                       = $date_time->getTimestamp();
+            $agenda->localized_meeting_date = wp_date( 'F j, Y', $sort_time, wp_timezone() );
         }
     } else {
-        //fallback to WP publish year if no meeting date
-        // $agenda->post_date = timber version of publish date
-        $post_timestamp = strtotime( $agenda->post_date );
-        $year = gmdate( 'Y', strtotime( $post_timestamp ) );
-        $agenda->localized_meeting_date = wp_date( 'F j, Y', $post_timestamp );
+        //fallback to WP publish date using WP site timezone
+        $date_time = date_create_immutable( $agenda->post_date, wp_timezone() );
+
+        if ( $date_time ) {
+            $year = $date_time->format( 'Y' );
+            $sort_time = $date_time->getTimestamp();
+            $agenda->localized_meeting_date = wp_date( 'F j, Y', $sort_time, wp_timezone() );
+        }
     }
     // AFTER finding the year, add it to the array
     if ( $year ) {
+        $agenda->sort_timestamp= $sort_time;
         $posts_by_year[ $year ][] = $agenda;
     }
 }
 
 //Sort so the years are in descending order (newest/latest to oldest/earliest)
 krsort( $posts_by_year );
+
+//Sort posts w/in each year descending by date (newest to oldest)
+foreach ( $posts_by_year as $year => &$posts ) {
+    usort( $posts, function( $a, $b ) {
+        return $b->sort_timestamp <=> $a->sort_timestamp;
+    } );
+}
+unset( $posts ); // Break reference
+
 //Pass  to Twig
 $context['posts_by_year'] = $posts_by_year;
 

--- a/src/controllers/page-templates/page.php
+++ b/src/controllers/page-templates/page.php
@@ -34,6 +34,9 @@ if ( get_option( 'page_on_front' ) ) {
 // Implode the pages array to a comma separated string
 $pages_to_hide = implode( ',', $pages_to_hide );
 
+$context['is_child_page']   = $context['post']->post_parent > 0;
+$context['site_name']       = get_bloginfo( 'name' );
+
 if ( $context['post']->post_parent > 0 ) {
 	$context['parent_page']['title'] = get_the_title( $context['post']->post_parent );
 	$context['parent_page']['url']   = get_permalink( $context['post']->post_parent );

--- a/stories/nav-sidebar/NavSidebar.stories.js
+++ b/stories/nav-sidebar/NavSidebar.stories.js
@@ -1,21 +1,45 @@
 import twigNavSidebar from "./nav-sidebar.twig";
 
+const sampleContextMenu = `
+	<div class="menu">
+		<ul>
+			<li class="page_item page-item-1 current_page_item"><a href="#">Current Page</a></li>
+			<li class="page_item page-item-2"><a href="#">Sibling Page</a></li>
+			<li class="page_item page-item-3 page_item_has_children">
+				<a href="#">Page with Children</a>
+				<ul class="children">
+					<li class="page_item"><a href="#">Child Page</a></li>
+				</ul>
+			</li>
+		</ul>
+	</div>
+`;
 
 export default {
-    title: "Stories/Navigation Sidebar",
-    component: "nav-sidebar",
-    tags: ['autodocs'],
+	title: "Stories/Navigation Sidebar",
+	component: "nav-sidebar",
+	tags: ["autodocs"],
 };
 
+const Template = (args) => twigNavSidebar(args);
 
-const Template = ( {
+export const ChildPage = Template.bind({});
+ChildPage.args = {
+	is_child_page: true,
+	parent_page: {
+		title: "Parent Section",
+		url: "#parent-section",
+	},
+	context_menu: sampleContextMenu,
+};
 
- }) =>
-    twigNavSidebar({
-
-    });
-
-export const Default = Template.bind({});
-Default.args = {
-
+export const TopLevelPage = Template.bind({});
+TopLevelPage.args = {
+	is_child_page: false,
+	parent_page: {
+		title: "Home",
+		url: "#home",
+	},
+	context_menu: sampleContextMenu,
+	site_name: "Example Department",
 };

--- a/stories/nav-sidebar/nav-sidebar.twig
+++ b/stories/nav-sidebar/nav-sidebar.twig
@@ -1,10 +1,15 @@
 <div class="nav-sidebar-wrapper">
 	<a class="visually-hidden-focusable" href="#after-nav-sidebar-landmark">Skip sidebar navigation</a>
-	<nav class="nav-sidebar rounded shadow accordion" id="nav-sidebar" aria-label="{{ __('In this section', 'bc-sitka-spruce') }}">
+	{% if is_child_page %}
+		{% set nav_title = __('More in this section', 'bc-sitka-spruce') %}
+	{% else %}
+		{% set nav_title = __('Explore %s', 'bc-sitka-spruce')|format(site_name) %}
+	{% endif %}
+	<nav class="nav-sidebar rounded shadow accordion" id="nav-sidebar" aria-label="{{ nav_title }}">
 		<div class="accordion-item">
 			<h2 class="accordion-header d-md-none">
 				<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#nav-sidebar-collapse" aria-expanded="false" aria-controls="nav-sidebar-collapse">
-					{{ __('More in this section', 'bc-sitka-spruce') }}
+					{{ nav_title }}
 				</button>
 			</h2>
 			<div id="nav-sidebar-collapse" class="accordion-collapse collapse p-3 d-md-block"  data-bs-parent="#nav-sidebar">

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
  * Theme Name:        BC "Sitka Spruce" Department Theme
  * Theme URI:         https://github.com/BellevueCollege/bc-sitka-spruce-department-theme
  * Description:       Theme for Bellevue College Level 3 Department Sites
- * Version:           1.9.2-prod-#{versionStamp}#
+ * Version:           1.9.3-prod-#{versionStamp}#
  * Author:            Bellevue College ITS Integration Team
  * Author URI:        https://www.bellevuecollege.edu
  * Tags:              block-patterns, accessibility-ready

--- a/views/content/archive-action-items.twig
+++ b/views/content/archive-action-items.twig
@@ -24,7 +24,7 @@
                 {% endset %}
                 {% set accordion_items = accordion_items|merge([{
                     id: 'year-' ~ year,
-                    title: year ~ ' Meetings',
+                    title: year ~ ' Action Items',
                     is_open: loop.first,
                     content: list_content,
                 }]) %}

--- a/views/content/single-action-item.twig
+++ b/views/content/single-action-item.twig
@@ -8,11 +8,9 @@
 
 {% block content %}
     {# Date is preformatted in PHP via wp_date / wp_timezone to avoid day offset. #}
-    {% set is_special = agenda_obj.meta('special_meeting') ? '(Special Meeting)' : '' %}
-
     <div class="flexible-page">
         {# Pass date into banner through subtitle #}
-        {% set banner_subtitle = post.localized_meeting_date ? (post.localized_meeting_date ~ ' ' ~ is_special) : is_special %}
+        {% set banner_subtitle = post.localized_meeting_date %}
 
         {% include '@stories/flexible-page-intro/flexible-page-intro.twig' with {
             title: post.title,

--- a/views/content/single-action-item.twig
+++ b/views/content/single-action-item.twig
@@ -13,19 +13,19 @@
         {% set banner_subtitle = post.localized_meeting_date %}
 
         {% include '@stories/flexible-page-intro/flexible-page-intro.twig' with {
-            title: post.title,
-            subtitle: banner_subtitle
+            title: post.title|default(''),
+            subtitle: banner_subtitle|default('')
         } %}
 
         <div class="action-item-single-page container-xl pb-4">
             <div class="row">
                 <div class="col-lg-8">
-                    {{ post.content }}
+                    {{ post.content|default('') }}
                 </div>
 
             {# Only show call out if one or more options exist #}
-            {% set agenda_id = post.meta('associated_agenda') %}
-            {% set resolution_id = post.meta('related_resolutions') %}
+            {% set agenda_id = post.meta('associated_agenda') ?: post.meta('associated-agenda') %}
+            {% set resolution_id = post.meta('related_resolutions') ?: post.meta('related-resolutions') %}
 
             {% if agenda_id or resolution_id %}
                 <div class="col-lg-4">
@@ -33,25 +33,37 @@
                         <ul class="list-unstyled mb-0">
                             {% if agenda_id %}
                                 {# Convert the raw ACF data into a Timber Post object #}
-                                {% set agenda = Post(agenda_id) %}
-                                <li><strong>Agenda:</strong>
-                                    <a href="{{ agenda.link }}">{{ agenda.title }}</a>
-                                </li>
+                                {% set agenda = get_post(agenda_id) %}
+                                {% if agenda %}
+                                    <li><strong>Agenda:</strong>
+                                        <a href="{{ agenda.link }}">{{ agenda.title|default('') }}</a>
+                                    </li>
                             {% endif %}
-                            {% if resolution_id %}
-                                {#Covert raw to timber Post Obj.#}
-                                {% set resolution = Post(resolution_id) %}
-                                <li class="{{ agenda_id ? 'mt-2' : '' }}">
-                                    <strong>Resolution:</strong> 
-                                    <a href="{{ resolution.link }}">{{ resolution.title }}</a>
-                                </li>
-                            {% endif %}
+                        {% endif %}
+
+                        {#Related Resolution#}
+                        {% if resolution_id %}
+                            {#Covert raw to timber Post Obj.#}
+                            {% set resolution = resolution_id is iterable ? resolution_id : [resolution_id] %}
+                            <li class="{{ agenda_id ? 'mt-2' : '' }}">
+                                {% for item in resolutions %}
+                                    {% set resolution = get_post(item) %}
+                                    {% if resolution %}
+                                        <strong>Resolution:</strong> 
+                                        <a href="{{ resolution.link }}">{{ resolution.title|default('') }}</a>
+                                    {% endif %}
+                                {% endfor %}
+                            </li>
+                        {% endif %}
                         </ul>
                     {% endset %}
 
                     {% include '@stories/callout/callout.twig' with {
                             title: 'Related Content',
-                            links: related_html,
+                            links: related_html ? related_html ~ '' : '',
+                            text: '',
+                            content: '',
+                            description: '',
                             wrapper_classes: 'callout-wrapper'
                     } %}
                 </div>

--- a/views/content/single-action-item.twig
+++ b/views/content/single-action-item.twig
@@ -44,7 +44,7 @@
                         {#Related Resolution#}
                         {% if resolution_id %}
                             {#Covert raw to timber Post Obj.#}
-                            {% set resolution = resolution_id is iterable ? resolution_id : [resolution_id] %}
+                            {% set resolutions = resolution_id is iterable ? resolution_id : [resolution_id] %}
                             <li class="{{ agenda_id ? 'mt-2' : '' }}">
                                 {% for item in resolutions %}
                                     {% set resolution = get_post(item) %}

--- a/views/content/single-agendas.twig
+++ b/views/content/single-agendas.twig
@@ -15,14 +15,14 @@
         {% set banner_subtitle = post.localized_meeting_date ? (post.localized_meeting_date ~ ' ' ~ is_special) : is_special %}
 
         {% include '@stories/flexible-page-intro/flexible-page-intro.twig' with {
-            title: post.title,
-            subtitle: banner_subtitle
+            title: post.title|default(''),
+            subtitle: banner_subtitle|default('')
         } %}
 
         <div class="single-agendas-page container pb-4">
             <div class="row">
                 <div class= "col-lg-8">
-                    {{ post.content }}
+                    {{ post.content|default('') }}
                 </div>
 
                 {% set action_items = post.meta('related_action_items') %}
@@ -41,15 +41,14 @@
                                 {% if action_items %}
                                     <li><strong> Action Items: </strong></li>
                                         <ul class='ms-3'>
-                                        {# Pulling in Bi-Directional Action Items #}
-                                        {% for item in action_items %}
-                                            {# If 'item' is already a post object use it directly
-                                            {# Otherwise, convert the ID into a Post object. #}
-                                            {% set action_obj = Post(item) %}
-                                            {% if action_obj %}
-                                                <li><a href="{{ action_obj.link }}">{{ action_obj.title }}</a></li>
-                                            {% endif %}
-                                        {% endfor %}
+                                            {# Pulling in Bi-Directional Action Items #}
+                                            {% for item in action_items %}
+                                                {# Convert ACF into Timber Post object #}
+                                                {% set action_item = get_post(item) %}
+                                                <li>
+                                                    <a href="{{ action_item.link }}">{{ action_item.title|default('') }}</a>
+                                                </li>
+                                            {% endfor %}
                                         </ul>
                                     </li>
                                 {% endif %}
@@ -58,14 +57,14 @@
                                 {% if resolutions %}
                                     <li class="{{ action_items ? 'mt-2' : '' }}"><strong>Resolutions:</strong>
                                         <ul class='ms-3'>
-                                        {# Pulling in Bi-Directional Resolutions #}
-                                        {% for item in resolutions %}
-                                            {# Convert the raw ACF data into a Timber Post object #}
-                                            {% set res_obj = Post(item) %}
-                                            {% if res_obj %}
-                                                <li><a href="{{ res_obj.link }}">{{ res_obj.title }}</a></li>
-                                            {% endif %}
-                                        {% endfor %}
+                                            {# Pulling in Bi-Directional Resolutions #}
+                                            {% for item in resolutions %}
+                                                {# Convert the raw ACF data into a Timber Post object #}
+                                                {% set resolution = get_post(item) %}
+                                                <li>
+                                                    <a href="{{resolution.link}}">{{ resolution.title|default('') }}</a>
+                                                </li>
+                                            {% endfor %}
                                         </ul>
                                     </li>
                                 {% endif %}
@@ -74,7 +73,10 @@
                             
                         {% include '@stories/callout/callout.twig' with {
                             title: 'Related Content',
-                            links: related_html,
+                            links: related_html ? related_html ~ '' : '',
+                            text: '',
+                            content: '',
+                            description: '',
                             wrapper_classes: 'callout-wrapper'
                         } %}
                     </div>

--- a/views/content/single-resolution.twig
+++ b/views/content/single-resolution.twig
@@ -25,7 +25,7 @@
 
                 {# call out display logic#}
                 {% set action_item_id = post.meta('associated_action_item') ?: post.meta('associated-action-item') %}
-                {% set agenda_id = post.met('associated_agenda') ?: post.meta('associated-agenda') %}
+                {% set agenda_id = post.meta('associated_agenda') ?: post.meta('associated-agenda') %}
             
                 {% if agenda_id or action_item_id %}
                     {# Pull in Associated Agenda #}
@@ -35,20 +35,23 @@
                                 {% if agenda_id %}
                                     {# Convert raw into Timber P. Obj.#}
                                     {% set agenda = get_post(agenda_id) %}
-                                    <li><strong>Agenda:</strong>
-                                        <a href="{{ agenda.link }}">{{ agenda.title }}</a>
-                                    </li>
+                                    {% if agenda %}
+                                        <li><strong>Agenda:</strong>
+                                            <a href="{{ agenda.link }}">{{ agenda.title }}</a>
+                                        </li>
+                                    {% endif %}
                                 {% endif %}
 
+                                {#Related Action Items #}
                                 {% if action_item_id %}
                                     {# Convert raw ACF into Timber P. Obj. #}
-                                    {% set action_item = action_item_id is iterable ? action_item_id : [action_item_id] %}
+                                    {% set action_items = action_item_id is iterable ? action_item_id : [action_item_id] %}
                                     <li class="{{ agenda_id ? 'mt-2' : '' }}">
                                     <strong>Action Item:</strong>
                                     {% for item in action_items %}
                                         {% set action_item = get_post(item) %}
                                             {% if action_item %}
-                                                <a href="{{ action_item.link }}">{{ action_item.title }}</a>
+                                                <a href="{{ action_item.link }}">{{ action_item.title|default('') }}</a>
                                             {% endif %}
                                         {% endfor %}
                                     </li>
@@ -59,6 +62,9 @@
                         {% include '@stories/callout/callout.twig' with {
                             title: 'Related Content',
                             links: related_html,
+                            text: '',
+                            content: '',
+                            description: '',
                             wrapper_classes: 'callout-wrapper'
                         } %}
                     </div>

--- a/views/content/single-resolution.twig
+++ b/views/content/single-resolution.twig
@@ -24,8 +24,8 @@
                 </div>
 
                 {# call out display logic#}
-                {% set action_item_id = post.meta('associated_action_item') %}
-                {% set agenda_id = post.meta('associated_agenda') %}
+                {% set action_item_id = post.meta('associated_action_item') ?: post.meta('associated-action-item') %}
+                {% set agenda_id = post.met('associated_agenda') ?: post.meta('associated-agenda') %}
             
                 {% if agenda_id or action_item_id %}
                     {# Pull in Associated Agenda #}
@@ -34,7 +34,7 @@
                             <ul class="list-unstyled mb-0">
                                 {% if agenda_id %}
                                     {# Convert raw into Timber P. Obj.#}
-                                    {% set agenda = Post(agenda_id) %}
+                                    {% set agenda = get_post(agenda_id) %}
                                     <li><strong>Agenda:</strong>
                                         <a href="{{ agenda.link }}">{{ agenda.title }}</a>
                                     </li>
@@ -42,10 +42,15 @@
 
                                 {% if action_item_id %}
                                     {# Convert raw ACF into Timber P. Obj. #}
-                                    {% set action_item = Post(action_item_id) %}
+                                    {% set action_item = action_item_id is iterable ? action_item_id : [action_item_id] %}
                                     <li class="{{ agenda_id ? 'mt-2' : '' }}">
                                     <strong>Action Item:</strong>
-                                        <a href="{{ action_item.link }}">{{ action_item.title }}</a>
+                                    {% for item in action_items %}
+                                        {% set action_item = get_post(item) %}
+                                            {% if action_item %}
+                                                <a href="{{ action_item.link }}">{{ action_item.title }}</a>
+                                            {% endif %}
+                                        {% endfor %}
                                     </li>
                                 {% endif %}
                             </ul>

--- a/views/content/single-resolution.twig
+++ b/views/content/single-resolution.twig
@@ -8,11 +8,9 @@
 
 {% block content %}
     {# Date is preformatted in PHP via wp_date / wp_timezone to avoid day offset. #}
-    {% set is_special = post.meta('special_meeting') ? '(Special Meeting)' : '' %}
-
     <div class="flexible-page">
         {# Pass date into banner through subtitle #}
-        {% set banner_subtitle = post.localized_meeting_date ? (post.localized_meeting_date ~ ' ' ~ is_special) : is_special %}
+        {% set banner_subtitle = post.localized_meeting_date %}
 
         {% include '@stories/flexible-page-intro/flexible-page-intro.twig' with {
             title: post.title,


### PR DESCRIPTION
Trustees Action Item Archive: Items Without Configured Dates Group Separately Within Year Accordions #519

Trustees Resolution Archive: Items Without Configured Dates Group Under Incorrect Year Headings #520

- single-action-item.twig: is_special removed
- single-resolution.twig: is_special removed
- Action Items Accordion Headings Title changed to {year] Action Items
- fixed archive-resolution so dates display in descending order