### PR TITLE
Refactor ACF block rendering to utilize a unified empty state template

### DIFF
--- a/src/blocks/announcement-banner/render.php
+++ b/src/blocks/announcement-banner/render.php
@@ -18,10 +18,13 @@ $context['links']       = get_field( 'links' ) ? array_map(
 	},
 	get_field( 'links' )
 ) : null;
-Timber::render( '/stories/announcement-banner/announcement-banner.twig', $context );
+$hasContent = (bool) $context['title'];
 
-if ( $is_preview && ! $context['title'] ) {
-	echo '<div class="announcement-wrapper-preview col"><p>';
-	_e( 'The  \'Announcement Banner Component\' is not configured. <br />Edit this element to configure it!', 'bc-sitka-spruce' );
-	echo '</p></div>';
+if ( $hasContent ) {
+	Timber::render( '/stories/announcement-banner/announcement-banner.twig', $context );
+} elseif ( $is_preview ) {
+	Timber::render( '/stories/atoms/block-empty-state/block-empty-state.twig', array(
+		'block_name'   => __( 'Announcement Banner Component', 'bc-sitka-spruce' ),
+		'instructions' => __( 'Select this element, then use the Settings sidebar to add content to this element so that it can display!', 'bc-sitka-spruce' ),
+	) );
 }

--- a/src/blocks/callout/editor.scss
+++ b/src/blocks/callout/editor.scss
@@ -3,10 +3,3 @@
 .callout__links ul {
 	padding-left: 0 !important;
 }
-
-.callout-wrapper.callout-disabled p {
-	opacity: 0.75;
-	font-style: italic;
-	margin: 2rem;
-}
-

--- a/src/blocks/callout/render.php
+++ b/src/blocks/callout/render.php
@@ -23,14 +23,13 @@ $context['heading_tag'] = 'h3';
 // 		'class' => 'card-body tab-content',
 // 	)
 // );
-if ( $context['enabled'] ) {
-	Timber::render( '/stories/callout/callout.twig', $context );
-} else {
-	echo '';
-}
+$hasContent = (bool) $context['enabled'];
 
-if ( $is_preview && ! $context['enabled'] ) {
-	echo '<div class="callout-wrapper callout-disabled col"><p>';
-	_e( 'The optional \'Callout\' sidebar is disabled. <br />Edit this element to enable it!', 'bc-sitka-spruce' );
-	echo '</p></div>';
+if ( $hasContent ) {
+	Timber::render( '/stories/callout/callout.twig', $context );
+} elseif ( $is_preview ) {
+	Timber::render( '/stories/atoms/block-empty-state/block-empty-state.twig', array(
+		'title'        => __( "The optional 'Callout' sidebar is disabled.", 'bc-sitka-spruce' ),
+		'instructions' => __( 'Edit this element to enable it!', 'bc-sitka-spruce' ),
+	) );
 }

--- a/src/blocks/checkerboard-section/render.php
+++ b/src/blocks/checkerboard-section/render.php
@@ -47,14 +47,13 @@ if ( ! empty( $block['align'] ) ) {
 $classes = array_map( 'sanitize_html_class', $classes );
 $context['classes'] = implode( ' ', $classes );
 
-if ( $context['title'] && $context['checkerboards'] ) {
-	Timber::render( '/stories/checkerboard-section/checkerboards.twig', $context );
-} else {
-	echo '';
-}
+$hasContent = $context['title'] && $context['checkerboards'];
 
-if ( $is_preview && ( ! $context['checkerboards'] || ! $context['title'] ) ) {
-	echo '<div class="card"><p>';
-	_e( 'Add title and checkerboards to this element so that it can display!', 'bc-sitka-spruce' );
-	echo '</p></div>';
+if ( $hasContent ) {
+	Timber::render( '/stories/checkerboard-section/checkerboards.twig', $context );
+} elseif ( $is_preview ) {
+	Timber::render( '/stories/atoms/block-empty-state/block-empty-state.twig', array(
+		'block_name'   => __( 'Checkerboard Section', 'bc-sitka-spruce' ),
+		'instructions' => __( 'Add title and checkerboards to this element so that it can display!', 'bc-sitka-spruce' ),
+	) );
 }

--- a/src/blocks/contact-selector/render.php
+++ b/src/blocks/contact-selector/render.php
@@ -30,7 +30,7 @@ if (is_array(get_field('profiles'))) {
 
         // Get the repeater data from the profile post
         $schedule_data = get_field('scheduling_section', $profile->ID);
-        
+
         // (Hard coded on purpose!) Check the first row of two specific fields
         if (is_array($schedule_data) && !empty($schedule_data)) {
             $section = $schedule_data[0]; // Get the first row
@@ -39,13 +39,13 @@ if (is_array(get_field('profiles'))) {
             if (!empty($section['schedule_appointment_link'])) {
                 $profile_data['scheduling_links'][] = $section['schedule_appointment_link'];
             }
-            
+
             // Check for the second link field
             if (!empty($section['sched_appt_link'])) {
                 $profile_data['scheduling_links'][] = $section['sched_appt_link'];
             }
         }
-        // Keep this for backward compatibility 
+        // Keep this for backward compatibility
         $profile_data['scheduling_link'] = $profile_data['scheduling_links'][0] ?? null;
 
         //add processed profile data to list
@@ -56,20 +56,13 @@ if (is_array(get_field('profiles'))) {
 // copying data from profiles to context
 $context['profiles'] = $profiles_data;
 
-// Showing message if use does not input any contacts (in preview, on editor side)
-if ( $is_preview && ! $context['profiles'] ) {
-	//echo '<div class="callout-wrapper callout-disabled"></div>';
-    echo '<div class="contact-selector-wrapper-preview col card"><p><strong>';
-	_e( 'The  \'Contact Selector Section\' is not configured.', 'bc-sitka-spruce' );
-	echo '</strong></p><p>';
-	_e( 'Select this element, then use the Settings sidebar to add a title, description, and choose contacts to display.', 'bc-sitka-spruce' );
-	echo '</p></div>';
-}
+$hasContent = ! empty( $context['profiles'] );
 
-
-// Render Twig Template, and if it's empty, return nothing
-if ( $context['profiles'] ) {
+if ( $hasContent ) {
 	Timber::render( '/stories/contact-item/contact-loop.twig', $context );
-} else {
-	echo '';
+} elseif ( $is_preview ) {
+	Timber::render( '/stories/atoms/block-empty-state/block-empty-state.twig', array(
+		'block_name'   => __( 'Contact Selector Section', 'bc-sitka-spruce' ),
+		'instructions' => __( 'Select this element, then use the Settings sidebar to add a title, description, and choose contacts to display.', 'bc-sitka-spruce' ),
+	) );
 }

--- a/src/blocks/degrees-certificates-section/render.php
+++ b/src/blocks/degrees-certificates-section/render.php
@@ -19,17 +19,16 @@ $context['segments']     = get_field( 'segments' ) ? array_map( function ( $segm
 	return $segment;
 }, get_field( 'segments' ) ) : array();
 
-$context['anchor'] = (isset($block['anchor']) && $block['anchor']) 
+$context['anchor'] = (isset($block['anchor']) && $block['anchor'])
 	? sanitize_title($block['anchor']) : '';
 
-if ( $context['title'] ) {
-	Timber::render( '/stories/degrees-certificates-section/degrees-certificates-section.twig', $context );
-} else {
-	echo '';
-}
+$hasContent = (bool) $context['title'];
 
-if ( $is_preview && ! $context['title'] ) {
-	echo '<div class="card"><p>';
-	_e( 'Select this element, then use the Settings sidebar to add content to this element so that it can display!', 'bc-sitka-spruce' );
-	echo '</p></div>';
+if ( $hasContent ) {
+	Timber::render( '/stories/degrees-certificates-section/degrees-certificates-section.twig', $context );
+} elseif ( $is_preview ) {
+	Timber::render( '/stories/atoms/block-empty-state/block-empty-state.twig', array(
+		'block_name'   => __( 'Degrees Certificates Section', 'bc-sitka-spruce' ),
+		'instructions' => __( 'Select this element, then use the Settings sidebar to add content to this element so that it can display!', 'bc-sitka-spruce' ),
+	) );
 }

--- a/src/blocks/hero-image/render.php
+++ b/src/blocks/hero-image/render.php
@@ -1,6 +1,8 @@
 <?php
-$site_type = get_field( 'site_type', 'option' );
 
+use Timber\Timber;
+
+$site_type = get_field( 'site_type', 'option' );
 
 if ( $site_type === 'div' ) {
 	$hero_image_size = 'featured-home-div-lg';
@@ -10,27 +12,27 @@ if ( $site_type === 'div' ) {
 	$hero_image_size = 'featured-home-dept-lg';
 }
 
-if ( get_field( 'hero_image' ) ) : ?>
+$hero_image_id = get_field( 'hero_image' );
+
+if ( $hero_image_id ) : ?>
 	<div class="hero">
 		<?php
 			echo wp_get_attachment_image(
-				get_field( 'hero_image' ),
+				$hero_image_id,
 				$hero_image_size,
 				false,
 				array(
 					'class' => 'img-fluid',
 				)
-			)
+			);
 		?>
 	</div>
-<?php else: ?>
+<?php elseif ( $is_preview ) : ?>
 	<?php
-		if ( $is_preview ) {
-			echo '<div class="card mw-100"><p class="my-0">';
-			_e( 'Add an optional \'Hero Image\' by selecting this block and using the Settings sidebar to choose or upload an image.', 'bc-sitka-spruce' );
-			echo '</p></div>';
-		} else {
-			echo '';
-		}
+	Timber::render( '/stories/atoms/block-empty-state/block-empty-state.twig', array(
+		'block_name'   => __( 'Hero Image', 'bc-sitka-spruce' ),
+		'instructions' => __( "Add an optional 'Hero Image' by selecting this block and using the Settings sidebar to choose or upload an image.", 'bc-sitka-spruce' ),
+		'variant'      => 'optional',
+	) );
 	?>
 <?php endif;

--- a/src/blocks/listing-section/listing-section-list-item-links/render.php
+++ b/src/blocks/listing-section/listing-section-list-item-links/render.php
@@ -13,14 +13,13 @@ $context['is_preview'] = $is_preview;
 
 $context['button'] = get_field( 'button' );
 
-if ( $context['links'] || $context['button'] ) {
-	Timber::render( '/stories/listing-section/list-item-links.twig', $context );
-} else {
-	echo '';
-}
+$hasContent = $context['links'] || $context['button'];
 
-if ( $is_preview && ! $context['links'] && ! $context['button'] ) {
-	echo '<div class="card"><p><i>';
-	_e( 'Select this element and use the Settings sidebar to add optional links or button', 'bc-sitka-spruce' );
-	echo '</i></p></div>';
+if ( $hasContent ) {
+	Timber::render( '/stories/listing-section/list-item-links.twig', $context );
+} elseif ( $is_preview ) {
+	Timber::render( '/stories/atoms/block-empty-state/block-empty-state.twig', array(
+		'instructions' => __( 'Select this element and use the Settings sidebar to add optional links or button', 'bc-sitka-spruce' ),
+		'variant' => 'optional',
+	) );
 }

--- a/src/blocks/media-gallery-section/render.php
+++ b/src/blocks/media-gallery-section/render.php
@@ -36,14 +36,13 @@ if ( ! empty( $block['align'] ) ) {
 $classes = array_map( 'sanitize_html_class', $classes );
 $context['classes'] = implode( ' ', $classes );
 
-if ( $context['title'] ) {
-	Timber::render( '/stories/media-gallery/media-gallery.twig', $context );
-} else {
-	echo '';
-}
+$hasContent = (bool) $context['title'];
 
-if ( $is_preview && ! $context['title'] ) {
-	echo '<div class="announcement-wrapper-preview col"><p>';
-	_e( 'The  \'Media Gallery Section\' is not configured. <br />Select this element, then use the Settings sidebar to configure it!', 'bc-sitka-spruce' );
-	echo '</p></div>';
+if ( $hasContent ) {
+	Timber::render( '/stories/media-gallery/media-gallery.twig', $context );
+} elseif ( $is_preview ) {
+	Timber::render( '/stories/atoms/block-empty-state/block-empty-state.twig', array(
+		'block_name'   => __( 'Media Gallery Section', 'bc-sitka-spruce' ),
+		'instructions' => __( 'Select this element, then use the Settings sidebar to configure it!', 'bc-sitka-spruce' ),
+	) );
 }

--- a/src/blocks/profiles-section/render.php
+++ b/src/blocks/profiles-section/render.php
@@ -109,14 +109,13 @@ $context['sections'] = get_field( 'sections' ) ? array_map(
 $explicit_anchor = isset( $block['anchor'] ) ? trim( (string) $block['anchor'] ) : '';
 $context['anchor_id'] = $explicit_anchor !== '' ? sanitize_title( $explicit_anchor ) : null;
 
-if ( $context['title'] ) {
-	Timber::render( '/stories/profiles-section/profiles-section.twig', $context );
-} else {
-	echo '';
-}
+$hasContent = (bool) $context['title'];
 
-if ( $is_preview && ! $context['title'] ) {
-	echo '<div class="card"><p>';
-	_e( 'Select this element, then use the Settings sidebar to add content to this element so that it can display!', 'bc-sitka-spruce' );
-	echo '</p></div>';
+if ( $hasContent ) {
+	Timber::render( '/stories/profiles-section/profiles-section.twig', $context );
+} elseif ( $is_preview ) {
+	Timber::render( '/stories/atoms/block-empty-state/block-empty-state.twig', array(
+		'block_name'   => __( 'Profiles Section', 'bc-sitka-spruce' ),
+		'instructions' => __( 'Select this element, then use the Settings sidebar to add content to this element so that it can display!', 'bc-sitka-spruce' ),
+	) );
 }

--- a/src/blocks/testimonial-section/render.php
+++ b/src/blocks/testimonial-section/render.php
@@ -45,14 +45,13 @@ if ( ! empty( $block['align'] ) ) {
 $classes = array_map( 'sanitize_html_class', $classes );
 $context['classes'] = implode( ' ', $classes );
 
-if ( $context['title'] ) {
-	Timber::render( '/stories/testimonial/testimonial.twig', $context );
-} else {
-	echo '';
-}
+$hasContent = (bool) $context['title'];
 
-if ( $is_preview && ! $context['title'] ) {
-	echo '<div class="card"><p>';
-	_e( 'Select this element, then use the Settings sidebar to add content to this element so that it can display!', 'bc-sitka-spruce' );
-	echo '</p></div>';
+if ( $hasContent ) {
+	Timber::render( '/stories/testimonial/testimonial.twig', $context );
+} elseif ( $is_preview ) {
+	Timber::render( '/stories/atoms/block-empty-state/block-empty-state.twig', array(
+		'block_name'   => __( 'Testimonial Section', 'bc-sitka-spruce' ),
+		'instructions' => __( 'Select this element, then use the Settings sidebar to add content to this element so that it can display!', 'bc-sitka-spruce' ),
+	) );
 }

--- a/stories/atoms/block-empty-state/BlockEmptyState.stories.js
+++ b/stories/atoms/block-empty-state/BlockEmptyState.stories.js
@@ -1,0 +1,82 @@
+import twigBlockEmptyState from './block-empty-state.twig';
+
+export default {
+	title: 'Stories/Atoms/Block Empty State',
+	component: 'block-empty-state',
+	tags: ['autodocs'],
+	argTypes: {
+		block_name: {
+			control: 'text',
+			description: 'Human label used to auto-generate the title (optional)',
+		},
+		title: {
+			control: 'text',
+			description: 'Override heading when block_name does not fit (optional)',
+		},
+		instructions: {
+			control: 'text',
+			description: 'Body text with sidebar guidance (required)',
+		},
+		variant: {
+			control: 'select',
+			options: ['unconfigured', 'disabled', 'optional'],
+			description: 'Visual treatment for the empty state',
+		},
+		classes: {
+			control: 'array',
+			description: 'Extra wrapper classes (optional)',
+		},
+	},
+};
+
+const Template = ({ block_name, title, instructions, variant, classes }) =>
+	twigBlockEmptyState({
+		block_name,
+		title,
+		instructions,
+		variant,
+		classes,
+	});
+
+export const Default = Template.bind({});
+Default.args = {
+	block_name: 'Contact Selector Section',
+	instructions:
+		'Select this element, then use the Settings sidebar to add a title, description, and choose contacts to display.',
+	variant: 'unconfigured',
+	classes: [],
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+	title: "The optional 'Callout' sidebar is disabled.",
+	instructions: 'Edit this element to enable it!',
+	variant: 'disabled',
+	classes: [],
+};
+
+export const Optional = Template.bind({});
+Optional.args = {
+	block_name: 'Hero Image',
+	instructions:
+		"Add an optional 'Hero Image' by selecting this block and using the Settings sidebar to choose or upload an image.",
+	variant: 'optional',
+	classes: [],
+};
+
+export const CustomTitle = Template.bind({});
+CustomTitle.args = {
+	title: 'No Department Selected!',
+	instructions:
+		'Select this block and use the Settings sidebar to configure what should be displayed.',
+	variant: 'unconfigured',
+	classes: [],
+};
+
+export const NoBlockName = Template.bind({});
+NoBlockName.args = {
+	instructions:
+		'Select this element and use the Settings sidebar to add optional links or button.',
+	variant: 'unconfigured',
+	classes: [],
+};

--- a/stories/atoms/block-empty-state/block-empty-state.twig
+++ b/stories/atoms/block-empty-state/block-empty-state.twig
@@ -1,0 +1,36 @@
+{#
+/**
+ * @file
+ * Editor-only empty state for ACF blocks that have no content yet.
+ *
+ * Variants map to Bootstrap utility classes so no custom CSS is required.
+ */
+#}
+{% set variant = variant|default('unconfigured') %}
+{% set classes = classes|default(['my-3']) %}
+
+{% if variant == 'disabled' %}
+	{% set variant_card_classes = 'border-0 bg-light' %}
+	{% set variant_body_classes = 'text-muted fst-italic' %}
+{% elseif variant == 'optional' %}
+	{% set variant_card_classes = 'border-0 bg-light' %}
+	{% set variant_body_classes = 'text-muted' %}
+{% else %}
+	{% set variant_card_classes = 'border-secondary bg-light' %}
+	{% set variant_body_classes = '' %}
+{% endif %}
+
+<div class="card {{ variant_card_classes }} {{ classes|join(' ') }}">
+	{% if title %}
+		<div class="card-header">
+			<h3 class="h5 mb-0">{{ title }}</h3>
+		</div>
+	{% elseif block_name %}
+		<div class="card-header">
+			<h3 class="h5 mb-0">{{ block_name }} {{ __('is not configured.', 'bc-sitka-spruce') }}</h3>
+		</div>
+	{% endif %}
+	<div class="card-body">
+		<p class="{{ variant_body_classes }} mb-0">{{ instructions }}</p>
+	</div>
+</div>


### PR DESCRIPTION
Add a new template to display a 'not configured' warning in the editor, and updated all ACF blocks to use a unified notice style and method of handling input.