### PR TITLE
Strip HTML markup from auto-populated SEO meta descriptions

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -381,6 +381,30 @@ add_filter( 'document_title_separator', function( $sep ) {
 	return ' - ';
 }, 10, 1 );
 
+/**
+ * Reduce an ACF field value to plain text, for use as a meta description.
+ *
+ * Both fields feeding the description filter below can carry markup. 'summary'
+ * is a textarea with 'new_lines' set to 'br', so ACF runs the stored text
+ * through nl2br() before get_field() returns it, and 'intro_text' is a textarea
+ * that can pick up tags when content is pasted in from a word processor. Line
+ * breaks and block level tags are turned into spaces first, so that
+ * '<p>One</p><p>Two</p>' does not collapse into 'OneTwo'.
+ *
+ * Returns an empty string for values that hold no text, which lets the filter
+ * fall through to the description The SEO Framework generates itself.
+ */
+function plain_text_meta_description( $value ): string {
+	if ( ! is_string( $value ) || '' === $value ) {
+		return '';
+	}
+
+	$value = preg_replace( '#<(?:br|/p|/div|/li|/h[1-6]|/blockquote)\b[^>]*>#i', ' ', $value );
+
+	// Strips the remaining tags, collapses whitespace, and trims.
+	return wp_strip_all_tags( $value, true );
+}
+
 // Use Summary or Intro as description by default
 // Inspired by https://gist.github.com/sybrew/299ad19597f974c89b1564316297c1ed
 add_filter( 'the_seo_framework_generated_description', function( $description, $context ) {
@@ -391,13 +415,15 @@ add_filter( 'the_seo_framework_generated_description', function( $description, $
 	if ( ! isset( $context['id'] ) ) return $description;
 
 	// If an Intro Text is available, return it.
-	if ( get_field( 'intro_text', $context['id'] ) && "" !== get_field( 'intro_text', $context['id'] ) ) {
-		return get_field( 'intro_text', $context['id'] );
+	$intro_text = plain_text_meta_description( get_field( 'intro_text', $context['id'] ) );
+	if ( '' !== $intro_text ) {
+		return $intro_text;
 	}
 
 	// If a Summary is available, return it (used on Posts)
-	if ( get_field( 'summary', $context['id'] ) && "" !== get_field( 'summary', $context['id'] ) ) {
-		return get_field( 'summary', $context['id'] );
+	$summary = plain_text_meta_description( get_field( 'summary', $context['id'] ) );
+	if ( '' !== $summary ) {
+		return $summary;
 	}
 
 	// Fall back to normal


### PR DESCRIPTION
This PR proposes stripping HTML markup out of the auto-populated SEO meta descriptions, so that the `intro_text` and `summary` ACF values reach `<meta name="description">` as plain text (Fixes #329). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/216. You can sign in with your GitHub ID to claim ownership of the project.

## What is happening

The `the_seo_framework_generated_description` filter in `functions.php` returns the `intro_text` and `summary` ACF values verbatim, and both fields can carry markup. `summary` is a textarea configured with `"new_lines": "br"` in `acf-json/group_678054acbd208.json`, so ACF runs the stored text through `nl2br()` before `get_field()` returns it, and `intro_text` is a textarea that picks up tags when copy is pasted in from a word processor.

The rest of the theme already accounts for this. `views/content/single-post.twig` and `views/content/subcomponents/post-list-element.twig` both pipe `summary` through `|striptags`, and `News.php`, `Department.php` and `SupportFeature.php` pass it through `wp_kses_post()`. The description filter is the one path that does not, so the markup ends up inside the description meta tag.

## Reproducing it on trunk

This runs the filter exactly as it is written in `functions.php` — it reads the registration straight out of the file rather than restating it — with `get_field()` returning what ACF produces for a `summary` field, and `wp_strip_all_tags()` copied from `wp-includes/formatting.php`:

```bash
cat > /tmp/desc-check.php <<'PHP'
<?php
$src = file_get_contents($argv[1]);
function add_filter($h, $c, $p = 10, $a = 1) { $GLOBALS['cb'] = $c; }
function get_field($name, $id = null) {
    // What ACF returns for `summary` (a textarea with "new_lines": "br").
    return $name === 'summary' ? "Applications open each spring.<br />\nCampus tours run monthly." : null;
}
function wp_strip_all_tags($text, $remove_breaks = false) { // wp-includes/formatting.php
    $text = preg_replace('@<(script|style)[^>]*?>.*?</\1>@si', '', (string) $text);
    $text = strip_tags($text);
    if ($remove_breaks) $text = preg_replace('/[\r\n\t ]+/', ' ', $text);
    return trim($text);
}
if (preg_match('/\nfunction\s+plain_text_meta_description.*?\n\}/s', $src, $h)) eval($h[0]);
preg_match("/add_filter\(\s*'the_seo_framework_generated_description'.*?\}, 10, 2 \);/s", $src, $m);
eval($m[0]);
echo $GLOBALS['cb']('The SEO Framework default.', ['id' => 1]), "\n";
PHP
php /tmp/desc-check.php functions.php
```

On `trunk` at 5625acf the description comes back with the tag still in it:

```
Applications open each spring.<br />
Campus tours run monthly.
```

With this PR applied, the same script prints:

```
Applications open each spring. Campus tours run monthly.
```

## The change

A `plain_text_meta_description()` helper reduces a field value to plain text. Line breaks and block level tags become spaces first, so that `<p>One</p><p>Two</p>` does not collapse into `OneTwo`, and `wp_strip_all_tags()` then removes what is left and collapses the whitespace. The filter runs both fields through it.

Two small behavior changes come with that, beyond the markup removal:

- A field holding only markup or whitespace, such as `<p></p>`, now yields an empty string and falls through to the description The SEO Framework generates itself. Previously such a value was truthy and was returned as the description.
- Each field is read once per request instead of two or three times.

HTML entities are deliberately left alone — `&amp;` stays `&amp;` — since that is the existing behavior and sits outside what this addresses.

## How it was verified

- The reproduction above, run against `trunk` and against this branch, with the output shown in both states.
- 14 cases exercised against the helper: adjacent paragraphs, headings, list items, `nl2br()` output, markup-only and whitespace-only values, `null`, a non-string value, `script` tags, plain text left untouched, and tags carrying attributes. All pass, and the plain-text cases confirm ordinary copy is returned unchanged.
- `composer install --no-interaction --prefer-dist --optimize-autoloader --no-dev` succeeds and `php -l` is clean across all 118 tracked PHP files, matching the same two checks run on `trunk` before the change.
- The npm half of your CI workflow is untouched by this PR, as no JS or SCSS changes here. It could not be exercised in our environment because `npm ci` needs the FontAwesome Pro token that `.npmrc` expects.

## How this was managed

We imported your issues, pull requests and milestones into a board — 507 stories in all — and worked this change on the story that came across from issue #329, at https://eastagiletracker.com/projects/216/stories/80107. The board itself is at https://eastagiletracker.com/projects/216.

![board](https://raw.githubusercontent.com/eastagiletracker/bc-sitka-spruce-department-theme/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
