### PR TITLE
Sidebar Wording

### DIFF
--- a/src/controllers/page-templates/page.php
+++ b/src/controllers/page-templates/page.php
@@ -34,6 +34,9 @@ if ( get_option( 'page_on_front' ) ) {
 // Implode the pages array to a comma separated string
 $pages_to_hide = implode( ',', $pages_to_hide );
 
+$context['is_child_page']   = $context['post']->post_parent > 0;
+$context['site_name']       = get_bloginfo( 'name' );
+
 if ( $context['post']->post_parent > 0 ) {
 	$context['parent_page']['title'] = get_the_title( $context['post']->post_parent );
 	$context['parent_page']['url']   = get_permalink( $context['post']->post_parent );

--- a/stories/nav-sidebar/NavSidebar.stories.js
+++ b/stories/nav-sidebar/NavSidebar.stories.js
@@ -1,21 +1,45 @@
 import twigNavSidebar from "./nav-sidebar.twig";
 
+const sampleContextMenu = `
+	<div class="menu">
+		<ul>
+			<li class="page_item page-item-1 current_page_item"><a href="#">Current Page</a></li>
+			<li class="page_item page-item-2"><a href="#">Sibling Page</a></li>
+			<li class="page_item page-item-3 page_item_has_children">
+				<a href="#">Page with Children</a>
+				<ul class="children">
+					<li class="page_item"><a href="#">Child Page</a></li>
+				</ul>
+			</li>
+		</ul>
+	</div>
+`;
 
 export default {
-    title: "Stories/Navigation Sidebar",
-    component: "nav-sidebar",
-    tags: ['autodocs'],
+	title: "Stories/Navigation Sidebar",
+	component: "nav-sidebar",
+	tags: ["autodocs"],
 };
 
+const Template = (args) => twigNavSidebar(args);
 
-const Template = ( {
+export const ChildPage = Template.bind({});
+ChildPage.args = {
+	is_child_page: true,
+	parent_page: {
+		title: "Parent Section",
+		url: "#parent-section",
+	},
+	context_menu: sampleContextMenu,
+};
 
- }) =>
-    twigNavSidebar({
-
-    });
-
-export const Default = Template.bind({});
-Default.args = {
-
+export const TopLevelPage = Template.bind({});
+TopLevelPage.args = {
+	is_child_page: false,
+	parent_page: {
+		title: "Home",
+		url: "#home",
+	},
+	context_menu: sampleContextMenu,
+	site_name: "Example Department",
 };

--- a/stories/nav-sidebar/nav-sidebar.twig
+++ b/stories/nav-sidebar/nav-sidebar.twig
@@ -1,10 +1,15 @@
 <div class="nav-sidebar-wrapper">
 	<a class="visually-hidden-focusable" href="#after-nav-sidebar-landmark">Skip sidebar navigation</a>
-	<nav class="nav-sidebar rounded shadow accordion" id="nav-sidebar" aria-label="{{ __('In this section', 'bc-sitka-spruce') }}">
+	{% if is_child_page %}
+		{% set nav_title = __('More in this section', 'bc-sitka-spruce') %}
+	{% else %}
+		{% set nav_title = __('Explore %s', 'bc-sitka-spruce')|format(site_name) %}
+	{% endif %}
+	<nav class="nav-sidebar rounded shadow accordion" id="nav-sidebar" aria-label="{{ nav_title }}">
 		<div class="accordion-item">
 			<h2 class="accordion-header d-md-none">
 				<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#nav-sidebar-collapse" aria-expanded="false" aria-controls="nav-sidebar-collapse">
-					{{ __('More in this section', 'bc-sitka-spruce') }}
+					{{ nav_title }}
 				</button>
 			</h2>
 			<div id="nav-sidebar-collapse" class="accordion-collapse collapse p-3 d-md-block"  data-bs-parent="#nav-sidebar">


### PR DESCRIPTION
Improve how sidebar is labelled when it transforms to accordion on mobile. 

Correctly lable as 'more in this section' when on child pages, and 'explore {site name} when on a root page.

Request from IA web team.